### PR TITLE
Feat: Fixed Ingress and NFS Mounts

### DIFF
--- a/radarr/radarr.yaml
+++ b/radarr/radarr.yaml
@@ -1,32 +1,4 @@
 ---
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: radarr-config-pvc
-  namespace: bakery-media
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 1Mi
-  storageClassName: config-nfs-client
-
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: radarr-media-pvc
-  namespace: bakery-media
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 1Mi
-  storageClassName: media-nfs-client
-
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -82,19 +54,20 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - name: radarr-media
+            - name: radarr-plexmedia
               mountPath: /mnt/media
-              subPath: k8s/
-            - name: radarr-config
+            - name: radarr-configs
               subPath: k8s-radarr/config/
               mountPath: /config
       volumes:
-        - name: radarr-config
-          persistentVolumeClaim:
-            claimName: radarr-config-pvc
-        - name: radarr-media
-          persistentVolumeClaim:
-            claimName: radarr-media-pvc
+        - name: radarr-plexmedia
+          nfs:
+            server: 10.0.0.199
+            path: /run/nfs4/cooling-rack/plex
+        - name: radarr-configs
+          nfs:
+            server: 10.0.0.199
+            path: /run/nfs4/backup/bakery-configs
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
 

--- a/sonarr/sonarr.yaml
+++ b/sonarr/sonarr.yaml
@@ -1,0 +1,86 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: sonarr
+  namespace: bakery-media
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: sonarr
+    spec:
+      containers:
+        - name: sonarr
+          env:
+            - name: TZ
+              value: PST
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+          image: linuxserver/sonarr:arm64v8-latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            tcpSocket:
+              port: 8989
+            initialDelaySeconds: 60
+          readinessProbe:
+            failureThreshold: 6
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8989
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 3
+            periodSeconds: 30
+            successThreshold: 1
+            tcpSocket:
+              port: 8989
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8989
+              name: http
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: sonarr-plexmedia
+              mountPath: /mnt/media
+            - name: sonarr-configs
+              subPath: k8s-sonarr/config/
+              mountPath: /config
+      volumes:
+        - name: sonarr-plexmedia
+          nfs:
+            server: 10.0.0.199
+            path: /run/nfs4/cooling-rack/plex
+        - name: sonarr-configs
+          nfs:
+            server: 10.0.0.199
+            path: /run/nfs4/backup/bakery-configs
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sonarr
+  namespace: bakery-media
+spec:
+  type: NodePort
+  ports:
+    - port: 8989
+      targetPort: 8989
+  selector:
+    app: sonarr

--- a/utilities/dnsutils.yaml
+++ b/utilities/dnsutils.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dnsutils
+  namespace: default
+spec:
+  containers:
+  - name: dnsutils
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    imagePullPolicy: IfNotPresent
+  restartPolicy: Always

--- a/utilities/nginx-ingress.yml
+++ b/utilities/nginx-ingress.yml
@@ -8,7 +8,6 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/add-base-url: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"


### PR DESCRIPTION
- Swaps to native NFS mounts instead of external StorageType to enable mounting of existing shares
- Fixes nginx ingress to get prefix pathing working
- Adds utility manifest for troubleshooting DNS